### PR TITLE
Improve static dependency and using tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ When there are too many services in cluster, envoy configuration is too much, an
 
 Introduce a service `global-sidecar`, which is used for request last matching. It will be injected sidecar container by Istiod. with a full configuration and service discovery information. The pass through route is replaced with a new one to the global-sidecar.
 
-Bring new Custom Resource `ServiceFence`. Details at [ServiceFence Instruction](#ServiceFence Instruction)
+Bring new Custom Resource `ServiceFence`. Details at [ServiceFence Instruction](#ServiceFence-Instruction)
 
 Finally, the control logic is included in the lazyload controller component. It will create ServiceFence and Sidecar for the lazyload enabled services, and update ServiceFence and Sidecar based on the service invocation relationship obtained from the configuration.
 

--- a/api/v1alpha1/service_fence.proto
+++ b/api/v1alpha1/service_fence.proto
@@ -83,8 +83,9 @@ message Timestamp {
 //   spec:
 //    enable: true
 //    host:
-//      reviews.default.svc.cluster.local: # stable dependency of reviews.default service
+//      reviews.default.svc.cluster.local: # static dependency of reviews.default service
 //        stable:
+//      test/*: {} # static dependency of all services in namespace 'test'
 //    namespaceSelector: # Match namespace names, multiple namespaces are 'or' relations, static dependency
 //      - foo
 //      - bar


### PR DESCRIPTION
fix #24 

- support config ns level in spec.host
- add doc

```yaml 
Spec Example
   spec:
    enable: true
    host:
      reviews.default.svc.cluster.local: # static dependency of reviews.default service
        stable:
      test/*: {} # static dependency of services in test namespace
    labelSelector: # Match service label, multiple selectors are 'or' relationship, static dependency
      - selector:
          project: back
      - selector: # labels in same selector are 'and' relationship
          project: front
          group: web