### PR TITLE
Bugfix for auto fence enable

### DIFF
--- a/charts/templates/cluster-global-sidecar.yaml
+++ b/charts/templates/cluster-global-sidecar.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
     app: global-sidecar
     service: global-sidecar
+    slime.io/serviceFenced: "false"
 spec:
   ports:
     {{- range .fence.wormholePort }}

--- a/charts/templates/namespace-global-sidecar.yaml
+++ b/charts/templates/namespace-global-sidecar.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app: global-sidecar
     service: global-sidecar
+    slime.io/serviceFenced: "false"
 spec:
   ports:
       {{- range $f.wormholePort }}

--- a/controllers/model.go
+++ b/controllers/model.go
@@ -6,6 +6,7 @@
 package controllers
 
 import (
+	"k8s.io/apimachinery/pkg/types"
 	"slime.io/slime/framework/model"
 	modmodel "slime.io/slime/modules/lazyload/model"
 	"sync"
@@ -30,5 +31,10 @@ type NsSvcCache struct {
 
 type LabelSvcCache struct {
 	Data map[LabelItem]map[string]struct{}
+	sync.RWMutex
+}
+
+type SvcSelectorCache struct {
+	Data map[types.NamespacedName]string
 	sync.RWMutex
 }

--- a/controllers/servicefence_controller.go
+++ b/controllers/servicefence_controller.go
@@ -64,6 +64,7 @@ type ServicefenceReconciler struct {
 	enabledNamespaces    map[string]bool
 	nsSvcCache           *NsSvcCache
 	labelSvcCache        *LabelSvcCache
+	svcSelectorCache     *SvcSelectorCache
 	defaultAddNamespaces []string
 }
 
@@ -92,7 +93,7 @@ func NewReconciler(cfg *v1alpha1.Fence, mgr manager.Manager, env bootstrap.Envir
 	}
 
 	// start service related cache
-	r.nsSvcCache, r.labelSvcCache, err = newSvcCache(env.K8SClient)
+	r.nsSvcCache, r.labelSvcCache, r.svcSelectorCache, err = newSvcCache(r.env)
 	if err != nil {
 		log.Errorf("init LabelSvcCache err: %v", err)
 		return nil


### PR DESCRIPTION
1. Adding no auto-fence label to the global-sidecar. It will not auto create fence for global-sidecar when enable fence at namespace level.
2. Auto created fence name equals svc.spec.selector instead of svc.name now. For example, for svc/details with `spec.selector[app]: details-new`, it will create `fence/details` in the previous version and will create `fence/details-new` now.