### PR TITLE
Make dynamic service dependency info durable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,6 @@ replace (
 	k8s.io/api => k8s.io/api v0.17.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.17.2
 
-	slime.io/slime/framework => github.com/slime-io/slime/framework v0.3.9
+	slime.io/slime/framework => github.com/slime-io/slime/framework v0.3.10
 //slime.io/slime/framework => ../slime/framework
 )

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/slime-io/slime/framework v0.3.9 h1:UIWl00Oh+xPzGHsQYDno1c1JIjt+UJK3rWwobinujj8=
-github.com/slime-io/slime/framework v0.3.9/go.mod h1:/oF27Hn6PNzYrz31xzvfz/XBEd360TGo2a4kKVBYuO8=
+github.com/slime-io/slime/framework v0.3.10 h1:d4aiC4DnM3NXCdqddlkH37XGo8iGXW03+XX+JiYm/s8=
+github.com/slime-io/slime/framework v0.3.10/go.mod h1:/oF27Hn6PNzYrz31xzvfz/XBEd360TGo2a4kKVBYuO8=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=


### PR DESCRIPTION
related to https://github.com/slime-io/slime/pull/138

Step 1: Make dynamic service dependency info be durable 
When lazyload starting, it will generate cache contains dynamic service dependency info from existed ServiceFences, which contains useful info in `status.metricStatus`. After this change, it will never cause dynamic relationships lost when lazyload pod restarting or deleting.
This step has been completed in this PR.

Step 2: Make dynamic service dependency info be time-sensitive
In step 1, lazyload will never delete dynamic service dependency info in any time. 
Suppose a dynamic dependency is not invoked again for a long time after a certain occurrence, at which point we should have a mechanism to delete the dynamic dependency. One scenario is that all service invocations record the time of the most recent invocation, that we globally set a time threshold that triggers deletion, and we also allow users to specify a dedicated time threshold for specific services. These will be done in subsequent development.
