### PR TITLE
Support prometheus as lazyload metric source in istio 1.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Features
 
-1. Supports 1.8+ versions of Istio, without invasiveness, details at [recommended versions of istio](https://github.com/slime-io/lazyload/issues/26#issuecomment-1053926465)
+1. Supports 1.8+ versions of Istio, without invasiveness, details at [recommended versions of istio](https://github.com/slime-io/lazyload/issues/26)
 2. Forwarding process supports all Istio traffic capabilities
 3. Independent of the number of services, no performance issues
 4. Flexible enabled lazyload with support for Namespace, Service and other dimensions

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,7 +17,7 @@
 
 ## 特点
 
-1. 支持1.8+的Istio版本，无侵入性，[版本适配详情](https://github.com/slime-io/lazyload/issues/26#issuecomment-1053926465)
+1. 支持1.8+的Istio版本，无侵入性，[版本适配详情](https://github.com/slime-io/lazyload/issues/26)
 2. 兜底转发过程支持Istio所有流量治理能力
 3. 兜底逻辑简单，与服务数量无关，无性能问题
 4. 支持Namespace，Service等维度灵活启用懒加载

--- a/charts/templates/cluster-global-sidecar.yaml
+++ b/charts/templates/cluster-global-sidecar.yaml
@@ -127,6 +127,58 @@ spec:
             {{- toYaml $gs.resources | nindent 12 }}
           securityContext:
             runAsUser: 1000
+---
+  {{- if or (not $g) (not $g.misc) (eq (default "prometheus" $g.misc.metricSourceType) "prometheus") }}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: global-sidecar-metadata-exchange-remove
+  namespace: {{ $.Values.namespace }}
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        proxy:
+          metadata:
+            SLIME_APP: LAZYLOAD_GLOBAL_SIDECAR
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: istio.metadata_exchange
+      patch:
+        operation: REMOVE
+    - applyTo: HTTP_FILTER
+      match:
+        proxy:
+          metadata:
+            SLIME_APP: LAZYLOAD_GLOBAL_SIDECAR
+        context: SIDECAR_OUTBOUND
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: istio.metadata_exchange
+      patch:
+        operation: REMOVE
+    - applyTo: HTTP_FILTER
+      match:
+        proxy:
+          metadata:
+            SLIME_APP: LAZYLOAD_GLOBAL_SIDECAR
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: istio.metadata_exchange
+      patch:
+        operation: REMOVE
+  {{- end }}
 {{ range $_, $ns := $f.namespace }}
 ---
 apiVersion: networking.istio.io/v1alpha3

--- a/charts/templates/namespace-global-sidecar.yaml
+++ b/charts/templates/namespace-global-sidecar.yaml
@@ -129,6 +129,58 @@ spec:
           securityContext:
             runAsUser: 1000
 ---
+  {{- if or (not $g) (not $g.misc) (eq (default "prometheus" $g.misc.metricSourceType) "prometheus") }}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: global-sidecar-metadata-exchange-remove
+  namespace: {{ $ns }}
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        proxy:
+          metadata:
+            SLIME_APP: LAZYLOAD_GLOBAL_SIDECAR
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: istio.metadata_exchange
+      patch:
+        operation: REMOVE
+    - applyTo: HTTP_FILTER
+      match:
+        proxy:
+          metadata:
+            SLIME_APP: LAZYLOAD_GLOBAL_SIDECAR
+        context: SIDECAR_OUTBOUND
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: istio.metadata_exchange
+      patch:
+        operation: REMOVE
+    - applyTo: HTTP_FILTER
+      match:
+        proxy:
+          metadata:
+            SLIME_APP: LAZYLOAD_GLOBAL_SIDECAR
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: istio.metadata_exchange
+      patch:
+        operation: REMOVE
+  {{- end }}
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"flag"
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
+
 	"slime.io/slime/modules/lazyload/pkg/proxy"
 )
 
@@ -16,7 +18,7 @@ func main() {
 		}
 	}()
 
-	var addr = flag.String("addr", "0.0.0.0:80", "The addr of the application.")
+	addr := flag.String("addr", "0.0.0.0:80", "The addr of the application.")
 	flag.Parse()
 
 	handler := &proxy.Proxy{}

--- a/controllers/model.go
+++ b/controllers/model.go
@@ -6,9 +6,10 @@
 package controllers
 
 import (
+	"sync"
+
 	"slime.io/slime/framework/model"
 	modmodel "slime.io/slime/modules/lazyload/model"
-	"sync"
 )
 
 var log = modmodel.ModuleLog.WithField(model.LogFieldKeyPkg, "controllers")

--- a/controllers/process.go
+++ b/controllers/process.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,7 +14,6 @@ import (
 	"slime.io/slime/framework/model"
 	"slime.io/slime/framework/model/metric"
 	lazyloadv1alpha1 "slime.io/slime/modules/lazyload/api/v1alpha1"
-	"strings"
 )
 
 const (
@@ -44,7 +45,6 @@ func (r *ServicefenceReconciler) WatchMetric() {
 			r.ConsumeMetric(metric)
 		}
 	}
-
 }
 
 func (r *ServicefenceReconciler) ConsumeMetric(metric metric.Metric) {
@@ -71,7 +71,6 @@ func (r *ServicefenceReconciler) Refresh(req reconcile.Request, value map[string
 
 	sf := &lazyloadv1alpha1.ServiceFence{}
 	err := r.Client.Get(context.TODO(), req.NamespacedName, sf)
-
 	if err != nil {
 		if errors.IsNotFound(err) {
 			sf = nil

--- a/controllers/producer.go
+++ b/controllers/producer.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	envoy_config_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	data_accesslog "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3"
 	prometheusApi "github.com/prometheus/client_golang/api"
@@ -22,10 +27,6 @@ import (
 	"slime.io/slime/framework/model/trigger"
 	"slime.io/slime/framework/util"
 	lazyloadapiv1alpha1 "slime.io/slime/modules/lazyload/api/v1alpha1"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -37,7 +38,6 @@ const (
 
 // call back function for watcher producer
 func (r *ServicefenceReconciler) handleWatcherEvent(event trigger.WatcherEvent) metric.QueryMap {
-
 	// check event
 	gvks := []schema.GroupVersionKind{
 		{Group: "networking.istio.io", Version: "v1beta1", Kind: "Sidecar"},
@@ -77,7 +77,6 @@ func (r *ServicefenceReconciler) handleWatcherEvent(event trigger.WatcherEvent) 
 
 // call back function for ticker producer
 func (r *ServicefenceReconciler) handleTickerEvent(event trigger.TickerEvent) metric.QueryMap {
-
 	// no need to check time duration
 
 	// generate query map for producer
@@ -115,7 +114,6 @@ func generateHandler(name, namespace, pName string, pHandler *v1alpha1.Prometheu
 }
 
 func newProducerConfig(env bootstrap.Environment) (*metric.ProducerConfig, error) {
-
 	// init metric source
 	var enablePrometheusSource bool
 	var prometheusSourceConfig metric.PrometheusSourceConfig
@@ -200,7 +198,6 @@ func newProducerConfig(env bootstrap.Environment) (*metric.ProducerConfig, error
 	}
 
 	return pc, nil
-
 }
 
 func newPrometheusSourceConfig(env bootstrap.Environment) (metric.PrometheusSourceConfig, error) {
@@ -222,7 +219,6 @@ func newPrometheusSourceConfig(env bootstrap.Environment) (metric.PrometheusSour
 }
 
 func newInitCache(env bootstrap.Environment) (map[string]map[string]string, error) {
-
 	result := make(map[string]map[string]string)
 
 	svfGvr := schema.GroupVersionResource{
@@ -265,7 +261,7 @@ func accessLogHandler(logEntry []*data_accesslog.HTTPAccessLogEntry, ipToSvcCach
 
 	tmpResult := make(map[string]map[string]int)
 	for _, entry := range logEntry {
-		//tmpValue := make(map[string]int)
+		// tmpValue := make(map[string]int)
 
 		// fetch sourceEp
 		sourceIp, err := fetchSourceIp(entry)

--- a/controllers/service_cache.go
+++ b/controllers/service_cache.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	stderrors "errors"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -118,5 +119,4 @@ func newSvcCache(clientSet *kubernetes.Clientset) (*NsSvcCache, *LabelSvcCache, 
 	}()
 
 	return nsSvcCache, labelSvcCache, nil
-
 }

--- a/controllers/servicefence_controller.go
+++ b/controllers/servicefence_controller.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"slime.io/slime/framework/model"
-	"slime.io/slime/framework/model/metric"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"slime.io/slime/framework/model"
+	"slime.io/slime/framework/model/metric"
 
 	istio "istio.io/api/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
@@ -133,7 +134,7 @@ func (r *ServicefenceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 		if errors.IsNotFound(err) {
 			// TODO should be recovered? maybe we should call refreshFenceStatusOfService here
 			log.Info("serviceFence is deleted")
-			//r.interestMeta.Pop(req.NamespacedName.String())
+			// r.interestMeta.Pop(req.NamespacedName.String())
 			delete(r.interestMeta, req.NamespacedName.String())
 			r.updateInterestMetaCopy()
 			return r.refreshFenceStatusOfService(context.TODO(), nil, req.NamespacedName)
@@ -307,7 +308,6 @@ func parseHost(sourceNs, h string) *types.NamespacedName {
 }
 
 func (r *ServicefenceReconciler) updateVisitedHostStatus(sf *lazyloadv1alpha1.ServiceFence) Diff {
-
 	domains := r.genDomains(sf)
 
 	delta := Diff{
@@ -341,7 +341,6 @@ func (r *ServicefenceReconciler) updateVisitedHostStatus(sf *lazyloadv1alpha1.Se
 }
 
 func (r *ServicefenceReconciler) genDomains(sf *lazyloadv1alpha1.ServiceFence) map[string]*lazyloadv1alpha1.Destinations {
-
 	domains := make(map[string]*lazyloadv1alpha1.Destinations)
 
 	addDomainsWithHost(domains, sf, r.nsSvcCache)
@@ -353,7 +352,6 @@ func (r *ServicefenceReconciler) genDomains(sf *lazyloadv1alpha1.ServiceFence) m
 
 // update domains with spec.host
 func addDomainsWithHost(domains map[string]*lazyloadv1alpha1.Destinations, sf *lazyloadv1alpha1.ServiceFence, nsSvcCache *NsSvcCache) {
-
 	checkStatus := func(now int64, strategy *lazyloadv1alpha1.RecyclingStrategy) lazyloadv1alpha1.Destinations_Status {
 		switch {
 		case strategy.Stable != nil:
@@ -373,7 +371,6 @@ func addDomainsWithHost(domains map[string]*lazyloadv1alpha1.Destinations, sf *l
 	}
 
 	for h, strategy := range sf.Spec.Host {
-
 		if strings.HasSuffix(h, "/*") {
 			// handle namespace level host, like 'default/*'
 			handleNsHost(h, domains, nsSvcCache)
@@ -381,7 +378,6 @@ func addDomainsWithHost(domains map[string]*lazyloadv1alpha1.Destinations, sf *l
 			// handle service level host, like 'a.default.svc.cluster.local' or 'a' or 'a.default'
 			handleSvcHost(h, strategy, checkStatus, domains, sf)
 		}
-
 	}
 }
 
@@ -430,8 +426,8 @@ func handleNsHost(h string, domains map[string]*lazyloadv1alpha1.Destinations, n
 
 func handleSvcHost(h string, strategy *lazyloadv1alpha1.RecyclingStrategy,
 	checkStatus func(now int64, strategy *lazyloadv1alpha1.RecyclingStrategy) lazyloadv1alpha1.Destinations_Status,
-	domains map[string]*lazyloadv1alpha1.Destinations, sf *lazyloadv1alpha1.ServiceFence) {
-
+	domains map[string]*lazyloadv1alpha1.Destinations, sf *lazyloadv1alpha1.ServiceFence,
+) {
 	now := time.Now().Unix()
 
 	fullHost := h
@@ -469,8 +465,8 @@ func handleSvcHost(h string, strategy *lazyloadv1alpha1.RecyclingStrategy,
 
 // update domains with spec.labelSelector
 func addDomainsWithLabelSelector(domains map[string]*lazyloadv1alpha1.Destinations, sf *lazyloadv1alpha1.ServiceFence,
-	labelSvcCache *LabelSvcCache) {
-
+	labelSvcCache *LabelSvcCache,
+) {
 	labelSvcCache.RLock()
 	defer labelSvcCache.RUnlock()
 
@@ -526,12 +522,10 @@ func addDomainsWithLabelSelector(domains map[string]*lazyloadv1alpha1.Destinatio
 		}
 
 	}
-
 }
 
 // update domains with Status.MetricStatus
 func addDomainsWithMetricStatus(domains map[string]*lazyloadv1alpha1.Destinations, sf *lazyloadv1alpha1.ServiceFence) {
-
 	for metricName := range sf.Status.MetricStatus {
 		metricName = strings.Trim(metricName, "{}")
 		if !strings.HasPrefix(metricName, "destination_service") && !strings.HasPrefix(metricName, "request_host") {
@@ -659,12 +653,12 @@ func (r *ServicefenceReconciler) newSidecar(sf *lazyloadv1alpha1.ServiceFence, e
 	// generate sidecar.spec.workloadSelector
 	// priority: sf.spec.workloadSelector.labels > sf.spec.workloadSelector.fromService
 	if sf.Spec.WorkloadSelector != nil && len(sf.Spec.WorkloadSelector.Labels) > 0 {
-		//sidecar.WorkloadSelector.Labels = sf.Spec.WorkloadSelector.Labels
+		// sidecar.WorkloadSelector.Labels = sf.Spec.WorkloadSelector.Labels
 		for k, v := range sf.Spec.WorkloadSelector.Labels {
 			sidecar.WorkloadSelector.Labels[k] = v
 		}
 	} else if sf.Spec.WorkloadSelector != nil && sf.Spec.WorkloadSelector.FromService {
-		//sidecar.WorkloadSelector.Labels = svc.Spec.Selector
+		// sidecar.WorkloadSelector.Labels = svc.Spec.Selector
 		for k, v := range svc.Spec.Selector {
 			sidecar.WorkloadSelector.Labels[k] = v
 		}

--- a/controllers/servicefence_controller.go
+++ b/controllers/servicefence_controller.go
@@ -604,7 +604,7 @@ func (r *ServicefenceReconciler) newSidecar(sf *lazyloadv1alpha1.ServiceFence, e
 	// check whether using namespace global-sidecar
 	// if so, init config of sidecar will adds */global-sidecar.${svf.ns}.svc.cluster.local
 	if env.Config.Global.Misc["globalSidecarMode"] == "namespace" {
-		hosts = append(hosts, fmt.Sprintf("./global-sidecar.%s.svc.cluster.local", sf.Namespace))
+		hosts = append(hosts, fmt.Sprintf("*/global-sidecar.%s.svc.cluster.local", sf.Namespace))
 	}
 
 	// remove duplicated hosts

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,6 @@ replace (
 	k8s.io/api => k8s.io/api v0.17.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.17.2
 
-	slime.io/slime/framework => github.com/slime-io/slime/framework v0.3.12-0.20220307092406-5d25611d4318
+	slime.io/slime/framework => github.com/slime-io/slime/framework v0.3.12
 //slime.io/slime/framework => ../slime/framework
 )

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/slime-io/slime/framework v0.3.12-0.20220307092406-5d25611d4318 h1:uKTIDUyeDrbZFvzz7CGVbhrjhKqNMm6bvpOX/qRp16Q=
-github.com/slime-io/slime/framework v0.3.12-0.20220307092406-5d25611d4318/go.mod h1:/oF27Hn6PNzYrz31xzvfz/XBEd360TGo2a4kKVBYuO8=
+github.com/slime-io/slime/framework v0.3.12 h1:5oPKSQdEZiMrtNyUU1/LySn+TgBYgiyGR8Nf50qeEJM=
+github.com/slime-io/slime/framework v0.3.12/go.mod h1:BiTWp0bvM1wP14G00R9iDBH9PRBYSSIwg8chrBt78yQ=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/install/init/deployment_slime-boot.yaml
+++ b/install/init/deployment_slime-boot.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: slime-boot
           # Replace this with the built image name
-          image: docker.io/slimeio/slime-boot:v0.3.8-c8a453d
+          image: docker.io/slimeio/slime-boot:v0.3.12_linux_amd64
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/install/samples/lazyload/slimeboot_cluster_accesslog.yaml
+++ b/install/samples/lazyload/slimeboot_cluster_accesslog.yaml
@@ -8,7 +8,7 @@ spec:
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
-    tag: v0.2.0-7ca7f04
+    tag: v0.2.2_linux_amd64
   module:
     - name: lazyload # custom value
       kind: lazyload # should be "lazyload"
@@ -46,4 +46,4 @@ spec:
           memory: 400Mi
       image:
         repository: docker.io/slimeio/slime-global-sidecar
-        tag: v0.2.0-7ca7f04
+        tag: v0.2.0-1b93bf7

--- a/install/samples/lazyload/slimeboot_cluster_prometheus.yaml
+++ b/install/samples/lazyload/slimeboot_cluster_prometheus.yaml
@@ -8,7 +8,7 @@ spec:
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
-    tag: v0.2.0-7ca7f04
+    tag: v0.2.2_linux_amd64
   module:
     - name: lazyload # custom value
       kind: lazyload # should be "lazyload"
@@ -53,4 +53,4 @@ spec:
           memory: 400Mi
       image:
         repository: docker.io/slimeio/slime-global-sidecar
-        tag: v0.2.0-7ca7f04
+        tag: v0.2.0-1b93bf7

--- a/install/samples/lazyload/slimeboot_logrotate.yaml
+++ b/install/samples/lazyload/slimeboot_logrotate.yaml
@@ -8,7 +8,7 @@ spec:
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
-    tag: v0.2.0-7ca7f04
+    tag: v0.2.2_linux_amd64
   module:
     - name: lazyload # custom value
       kind: lazyload # should be "lazyload"
@@ -49,7 +49,7 @@ spec:
           memory: 400Mi
       image:
         repository: docker.io/slimeio/slime-global-sidecar
-        tag: v0.2.0-7ca7f04
+        tag: v0.2.0-1b93bf7
   volumes:
     - name: lazyload-storage
       persistentVolumeClaim:

--- a/install/samples/lazyload/slimeboot_namespace_accesslog.yaml
+++ b/install/samples/lazyload/slimeboot_namespace_accesslog.yaml
@@ -8,7 +8,7 @@ spec:
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
-    tag: v0.2.0-7ca7f04
+    tag: v0.2.2_linux_amd64
   module:
     - name: lazyload # custom value
       kind: lazyload # should be "lazyload"
@@ -46,4 +46,4 @@ spec:
           memory: 400Mi
       image:
         repository: docker.io/slimeio/slime-global-sidecar
-        tag: v0.2.0-7ca7f04
+        tag: v0.2.0-1b93bf7

--- a/install/samples/lazyload/slimeboot_namespace_prometheus.yaml
+++ b/install/samples/lazyload/slimeboot_namespace_prometheus.yaml
@@ -8,7 +8,7 @@ spec:
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
-    tag: v0.2.0-7ca7f04
+    tag: v0.2.2_linux_amd64
   module:
     - name: lazyload # custom value
       kind: lazyload # should be "lazyload"
@@ -53,4 +53,4 @@ spec:
           memory: 400Mi
       image:
         repository: docker.io/slimeio/slime-global-sidecar
-        tag: v0.2.0-7ca7f04
+        tag: v0.2.0-1b93bf7

--- a/install/samples/lazyload/slimeboot_no_global_sidecar.yaml
+++ b/install/samples/lazyload/slimeboot_no_global_sidecar.yaml
@@ -7,7 +7,7 @@ spec:
   image:
     pullPolicy: Always
     repository: docker.io/slimeio/slime-lazyload
-    tag: v0.2.0-7ca7f04
+    tag: v0.2.2_linux_amd64
   module:
     - name: lazyload # custom value
       kind: lazyload # should be "lazyload"

--- a/module/module.go
+++ b/module/module.go
@@ -1,11 +1,13 @@
 package module
 
 import (
+	"os"
+
 	"github.com/golang/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"os"
+
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	istioapi "slime.io/slime/framework/apis"
@@ -50,7 +52,6 @@ func (mo *Module) Clone() module.Module {
 }
 
 func (mo *Module) InitManager(mgr manager.Manager, env bootstrap.Environment, cbs module.InitCallbacks) error {
-
 	cfg := &mo.config
 
 	sfReconciler := controllers.NewReconciler(cfg, mgr, env)

--- a/pkg/proxy/http.go
+++ b/pkg/proxy/http.go
@@ -3,13 +3,14 @@ package proxy
 import (
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -17,8 +18,7 @@ const (
 	HeaderOrigDest = "Slime-Orig-Dest"
 )
 
-type HealthzProxy struct {
-}
+type HealthzProxy struct{}
 
 func (p *HealthzProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// health check
@@ -28,8 +28,7 @@ func (p *HealthzProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
-type Proxy struct {
-}
+type Proxy struct{}
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"testing"
+
 	framework2 "slime.io/slime/framework/test/e2e/framework"
 	"slime.io/slime/framework/test/e2e/framework/testfiles"
-	"testing"
 
 	"github.com/golang/glog"
 	"github.com/onsi/ginkgo"
@@ -30,7 +31,7 @@ func RunE2ETests(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	var r []ginkgo.Reporter
-	var ReportDir = "reports"
+	ReportDir := "reports"
 
 	if framework2.TestContext.ReportDir != "" {
 		ReportDir = framework2.TestContext.ReportDir

--- a/test/e2e/lazyload_test.go
+++ b/test/e2e/lazyload_test.go
@@ -1,18 +1,20 @@
 package e2e
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
 	"github.com/onsi/ginkgo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"os"
-	"os/exec"
-	"path/filepath"
+
 	"slime.io/slime/framework/test/e2e/framework"
 	e2epod "slime.io/slime/framework/test/e2e/framework/pod"
 	"slime.io/slime/framework/test/e2e/framework/testfiles"
-	"strings"
-	"time"
 )
 
 var _ = ginkgo.Describe("Slime e2e test", func() {
@@ -198,7 +200,6 @@ func createExampleApps(f *framework.Framework) {
 }
 
 func createServiceFence(f *framework.Framework, strictRev bool) {
-
 	// create CR ServiceFence
 	serviceFenceYaml := readFile(test, "samples/lazyload/servicefence_productpage.yaml")
 	serviceFenceYaml = strings.ReplaceAll(serviceFenceYaml, "{{istioRevKey}}", substituteValue("istioRevKey", istioRevKey))
@@ -263,7 +264,6 @@ func createServiceFence(f *framework.Framework, strictRev bool) {
 }
 
 func updateSidecar(f *framework.Framework) {
-
 	pods, err := f.ClientSet.CoreV1().Pods(nsApps).List(metav1.ListOptions{})
 	framework.ExpectNoError(err)
 ExecLoop:
@@ -284,7 +284,7 @@ ExecLoop:
 					continue
 				}
 				break ExecLoop
-				//framework.ExpectNoError(err)
+				// framework.ExpectNoError(err)
 			}
 		}
 	}
@@ -374,5 +374,5 @@ func cleanupKubectlInputs(ns string, fileContents string, selectors ...string) {
 	// support backward compatibility : file paths or raw json - since we are removing file path
 	// dependencies from this test.
 	framework.RunKubectlOrDieInput(ns, fileContents, "delete", "--grace-period=0", "--force", "-f", "-")
-	//assertCleanup(ns, selectors...)
+	// assertCleanup(ns, selectors...)
 }


### PR DESCRIPTION
In istio 1.12+, the way of metadata_exchange filters insertion is changed, related pr [Add metadata exchange as native code](https://github.com/istio/istio/pull/35212). So global-sidecar will be inserted these filters.

Then prometheus metric, what we want is like `service A -> service B`, will be `service A -> global-sidecar` and `global-sidecar -> service B`. Lazyload cannot get right relationships anymore in previous version with prometheus metric mode.

In this pr, we remove metadata_exchange filters from global-sidecar via the envoyfilter named `global-sidecar-metadata-exchange-remove`, and this problem is solved.

### Note
**All versions of 1.12+ istio (latest version 1.13.2 so far) has problem with envoyfilter remove operation, causing lazyload cannot run on these versions,** related issue [EnvoyFilter VIRTUAL_HOST REMOVE patch operation will destroy route configuration #36357](https://github.com/istio/istio/issues/36357).  And the last bugfix commit is [fix filter removal for http filter](https://github.com/istio/istio/pull/37903) at 2022.03.16, not contained by any istio realease.

We will provide a new istiod image version with latest istio code in order to run lazyload with prometheus metric later.
