### PR TITLE
Improve global-sidecar request forwarding capabilities

### DIFF
--- a/charts/templates/cluster-global-sidecar.yaml
+++ b/charts/templates/cluster-global-sidecar.yaml
@@ -30,7 +30,7 @@ spec:
     - name: http-{{ . }}
       port: {{ int . }}
       protocol: TCP
-      targetPort: 80
+      targetPort: {{ int . }}
     {{- end }}
   selector:
     app: global-sidecar
@@ -53,7 +53,7 @@ metadata:
   labels:
     app: global-sidecar
 spec:
-  replicas: 1
+  replicas: {{ $gs.replicas | default 1 }}
   selector:
     matchLabels:
       app: global-sidecar
@@ -95,6 +95,13 @@ spec:
       serviceAccountName: global-sidecar
       containers:
         - name: global-sidecar
+          env:
+            - name: PROBE_PORT
+              value: {{ default 18181 $gs.probePort | quote }}
+            - name: LOG_LEVEL
+              value: {{ default "info" $g.log.logLevel }}
+            - name: WORMHOLE_PORTS
+              value: {{ join "," $f.wormholePort | quote }}
           {{- if $gs.image.tag }}
           image: "{{ $gs.image.repository }}:{{ $gs.image.tag}}"
           {{- else }}
@@ -102,12 +109,15 @@ spec:
           {{- end }}
           imagePullPolicy: Always
           ports:
-            - containerPort: 80
+            {{- range $f.wormholePort }}
+            - containerPort: {{ int . }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /healthz/live
-              port: 8080
+              port: {{ default 18181 $gs.probePort }}
               scheme: HTTP
             initialDelaySeconds: 600
             periodSeconds: 30
@@ -117,7 +127,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 8080
+              port: {{ default 18181 $gs.probePort }}
               scheme: HTTP
             initialDelaySeconds: 1
             periodSeconds: 2

--- a/charts/templates/namespace-global-sidecar.yaml
+++ b/charts/templates/namespace-global-sidecar.yaml
@@ -31,7 +31,7 @@ spec:
       - name: http-{{ . }}
         port: {{ int . }}
         protocol: TCP
-        targetPort: 80
+        targetPort: {{ int . }}
       {{- end }}
   selector:
     app: global-sidecar
@@ -54,7 +54,7 @@ metadata:
   labels:
     app: global-sidecar
 spec:
-  replicas: 1
+  replicas: {{ $gs.replicas | default 1 }}
   selector:
     matchLabels:
       app: global-sidecar
@@ -96,6 +96,13 @@ spec:
       serviceAccountName: global-sidecar
       containers:
         - name: global-sidecar
+          env:
+            - name: PROBE_PORT
+              value: {{ default 18181 $gs.probePort | quote }}
+            - name: LOG_LEVEL
+              value: {{ default "info" $g.log.logLevel }}
+            - name: WORMHOLE_PORTS
+              value: {{ join "," $f.wormholePort | quote }}
           {{- if $gs.image.tag }}
           image: "{{ $gs.image.repository }}:{{ $gs.image.tag }}"
           {{- else }}
@@ -103,12 +110,15 @@ spec:
           {{- end }}
           imagePullPolicy: Always
           ports:
-            - containerPort: 80
+            {{- range $f.wormholePort }}
+            - containerPort: {{ int . }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /healthz/live
-              port: 8080
+              port: {{ default 18181 $gs.probePort }}
               scheme: HTTP
             initialDelaySeconds: 600
             periodSeconds: 30
@@ -118,7 +128,7 @@ spec:
             failureThreshold: 30
             httpGet:
               path: /healthz/ready
-              port: 8080
+              port: {{ default 18181 $gs.probePort }}
               scheme: HTTP
             initialDelaySeconds: 1
             periodSeconds: 2

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,30 +1,80 @@
 package main
 
 import (
-	"flag"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
 	"slime.io/slime/modules/lazyload/pkg/proxy"
 )
 
+const (
+	EnvWormholePorts = "WORMHOLE_PORTS"
+	EnvProbePort     = "PROBE_PORT"
+	EnvLogLevel      = "LOG_LEVEL"
+)
+
 func main() {
+	// set log config
+	logLevel := os.Getenv(EnvLogLevel)
+	if logLevel == "" {
+		logLevel = "info"
+	}
+	level, err := log.ParseLevel(logLevel)
+	if err != nil {
+		os.Exit(1)
+	}
+	log.SetLevel(level)
+	log.SetFormatter(&log.TextFormatter{
+		TimestampFormat: time.RFC3339,
+	})
+
+	// start health check server
+	probePort := ":" + os.Getenv(EnvProbePort)
 	go func() {
 		handler := &proxy.HealthzProxy{}
-		log.Println("Starting health check on :8080")
-		if err := http.ListenAndServe(":8080", handler); err != nil {
+		log.Println("Starting health check on", probePort)
+		if err := http.ListenAndServe(probePort, handler); err != nil {
 			log.Fatal("ListenAndServe:", err)
 		}
 	}()
 
-	addr := flag.String("addr", "0.0.0.0:80", "The addr of the application.")
-	flag.Parse()
+	// start multi ports defined in WormholePorts
+	wormholePorts := os.Getenv(EnvWormholePorts)
+	wormholePortsArr := strings.Split(wormholePorts, ",")
+	var whPorts []int
+	for _, whp := range wormholePortsArr {
+		if whp == probePort {
+			log.Errorf("wormholePort can not be %s, which is reserved for health check", probePort)
+			os.Exit(1)
+		}
 
-	handler := &proxy.Proxy{}
-
-	log.Println("Starting proxy server on", *addr)
-	if err := http.ListenAndServe(*addr, handler); err != nil {
-		log.Fatal("ListenAndServe:", err)
+		p, err := strconv.Atoi(whp)
+		if err != nil {
+			log.Errorf("wrong wormholePort value %s", whp)
+			os.Exit(1)
+		}
+		whPorts = append(whPorts, p)
 	}
+
+	var wg sync.WaitGroup
+	for _, whPort := range whPorts {
+		wg.Add(1)
+		handler := &proxy.Proxy{WormholePort: whPort}
+		go func(whPort int) {
+			log.Println("Starting proxy on", "0.0.0.0"+":"+strconv.Itoa(whPort))
+			if err := http.ListenAndServe("0.0.0.0"+":"+strconv.Itoa(whPort), handler); err != nil {
+				log.Fatal("Proxy ListenAndServe error:", err)
+			}
+			wg.Done()
+		}(whPort)
+	}
+
+	wg.Wait()
+	log.Infof("All servers exited.")
 }

--- a/controllers/domain.go
+++ b/controllers/domain.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"regexp"
+
 	lazyloadv1alpha1 "slime.io/slime/modules/lazyload/api/v1alpha1"
 )
 
@@ -25,7 +26,7 @@ func newDomainAliasRules(domainAlias []*lazyloadv1alpha1.DomainAlias) []*domainA
 			log.Errorf("domainAlias template is empty")
 			return nil
 		}
-		rule :=  &domainAliasRule{
+		rule := &domainAliasRule{
 			pattern:   pattern,
 			templates: templates,
 			re:        re,

--- a/install/samples/lazyload/slimeboot_cluster_accesslog.yaml
+++ b/install/samples/lazyload/slimeboot_cluster_accesslog.yaml
@@ -45,3 +45,4 @@ spec:
       image:
         repository: docker.io/slimeio/slime-global-sidecar
         tag: v0.2.0-1b93bf7
+      probePort: 8080


### PR DESCRIPTION
## Problem Solved

Global-sidecar would calculate the destination address to be forwarded based on the request header "Slime-Orig-Dest" when forwarding the request previously. When the request header "Slime-Orig-Dest" is empty, forwarding is rejected.

This PR extends the use of the global-sidecar scenario. When the request header "Slime-Orig-Dest" is empty, global-sidecar uses the request.host and the port on which the global-sidecar accepts the request as the destinatiuon address. Then request forwards directly, without generating an accesslog metric.

<img width="660" alt="disaster-recovery-arc" src="https://user-images.githubusercontent.com/22366230/163982196-5fd6d1a6-b89e-460f-b261-7c7a25ccf41a.png">
* The picture is not accurate enough. Traffic forwarded by global-sidecar is routed through the sidecarProxy when it reaches the destination, unless traffic hijacking has been disabled.

This allows business traffic to be directed to the global-sidecar for correct forwarding when there is a problem with some business sidecarProxy. This implies some sense of disaster recovery capability.

## Notes
 - `general.wormholePort` defines requests of which service ports should be forwarded, connected by ";"
 - replicas of global-sidecar can be defined in `component.globalSidecar.replicas`
 - resources of global-sidecar can be defined in `component.globalSidecar.resources`

## Usage Example
```yaml
---
apiVersion: config.netease.com/v1alpha1
kind: SlimeBoot
metadata:
  name: lazyload
  namespace: mesh-operator
spec:
  image:
    pullPolicy: Always
    repository: registry.cn-hangzhou.aliyuncs.com/slimeio/slime-lazyload
    tag: master-78f3d09_linux_amd64-dirty_e09cde4
  module:
    - name: lazyload-test
      kind: lazyload
      enable: true
      general:
        wormholePort: # replace to your application service ports, and extend the list in case of multi ports
          - "9080"
          - "9090"
      global:
        misc:
          globalSidecarMode: cluster
          metricSourceType: accesslog
  component:
    globalSidecar:
      enable: true
      sidecarInject:
        enable: true # should be true
        mode: pod
        labels:
          sidecar.istio.io/inject: "true"
      replicas: 2
      resources:
        requests:
          cpu: 200m
          memory: 200Mi
        limits:
          cpu: 400m
          memory: 400Mi
      image:
        repository: registry.cn-hangzhou.aliyuncs.com/slimeio/slime-global-sidecar
        tag: master-5d96f4d_linux_amd64
      probePort: 28888
```

